### PR TITLE
Updating IOPS limits based on azure portal

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -95,7 +95,7 @@ params:
       type: integer
     iops:
       title: Max IOPS
-      description: This feature enables you to provision additional IOPS above the complimentary IOPS limit. Max IOPS are determined by your compute size above (minimum of 450, maximum determined by your Compute size).
+      description: This feature enables you to provision additional IOPS above the complimentary IOPS limit (minimum of 450, maximum determined by your Compute size).
       minimum: 450
       maximum: 18000
       type: integer


### PR DESCRIPTION
Azure portal sets different limits than Terraform documentation. Terraform documentation has a range of `360` to `20000`, and Azure portal has limits of `450` to max of `18000`. Updating to match Azure portal.